### PR TITLE
Strip-off Batteries dependency

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -24,5 +24,5 @@ SourceRepository master
 
 Library "resource-pooling"
   Path: src
-  BuildDepends: lwt (>= 2.4.7 && < 4.0.0), batteries
+  BuildDepends: lwt (>= 2.4.7 && < 4.0.0)
   Modules: Resource_pool, Server_pool

--- a/opam/opam
+++ b/opam/opam
@@ -23,7 +23,6 @@ build-test: [
   ["ocaml" "setup.ml" "-test"]
 ]
 depends: [
-  "batteries"
   ("lwt" {>= "2.4.7" & < "4.0.0"})
   ("oasis" {build & >= "0.4.7"} | "oasis-mirage" {build & >= "0.4.7"})
   "ocamlbuild" {build}

--- a/src/server_pool.mli
+++ b/src/server_pool.mli
@@ -10,6 +10,7 @@ module type CONF = sig
   type connection
   type server
   type serverid
+  val serverid_to_string : serverid -> string (* for debugging purposes *)
   val connect : server -> connection Lwt.t
   val close : connection -> unit Lwt.t
 end


### PR DESCRIPTION
Needed changes:

- Inline small part of BatDllist
- Replace uses of BatPervasives.dump by the user-provided `Server_pool.CONF.serverid_to_string` converter.

My translation is a little dumb (& untested). @jrochel, can you verify the following?

- The exception `Empty` doesn't cause any trouble
- `Hashtbl.fold` can return the multiple key many times. Is this OK?